### PR TITLE
Fixed Content-Length header update

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,13 @@
 buildscript {
     repositories {
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
         jcenter()
     }
 
     dependencies {
-        classpath 'com.github.jengelman.gradle.plugins:shadow:+'
+        classpath 'com.github.jengelman.gradle.plugins:shadow:5.2.0'
     }
 }
 

--- a/src/burp/Replacements/Replacement.java
+++ b/src/burp/Replacements/Replacement.java
@@ -223,10 +223,16 @@ public class Replacement {
 
   // This is a hack around binary content causing requests to send
   private byte[] updateContent(byte[] request) {
+    IExtensionHelpers helpers = BurpExtender.getHelpers();
+    IRequestInfo analyzedRequest = helpers.analyzeRequest(request);
+    List<String> headers = analyzedRequest.getHeaders();
+    byte[] body = Arrays.copyOfRange(request, analyzedRequest.getBodyOffset(), request.length);
     if (replaceFirst()) {
-      return Utils.byteArrayRegexReplaceFirst(request, this.match, this.replace);
+      byte[] updatedBody = Utils.byteArrayRegexReplaceFirst(body, this.match, this.replace);
+      return helpers.buildHttpMessage(headers, updatedBody);
     } else {
-      return Utils.byteArrayRegexReplaceAll(request, this.match, this.replace);
+      byte[] updatedBody = Utils.byteArrayRegexReplaceFirst(body, this.match, this.replace);
+      return helpers.buildHttpMessage(headers, updatedBody);
     }
   }
 

--- a/src/burp/Replacements/Replacement.java
+++ b/src/burp/Replacements/Replacement.java
@@ -231,7 +231,7 @@ public class Replacement {
       byte[] updatedBody = Utils.byteArrayRegexReplaceFirst(body, this.match, this.replace);
       return helpers.buildHttpMessage(headers, updatedBody);
     } else {
-      byte[] updatedBody = Utils.byteArrayRegexReplaceFirst(body, this.match, this.replace);
+      byte[] updatedBody = Utils.byteArrayRegexReplaceAll(body, this.match, this.replace);
       return helpers.buildHttpMessage(headers, updatedBody);
     }
   }


### PR DESCRIPTION
Recently getting request timeouts error when using `Request String` type replacement. On digging further, found out that it's due to incorrect ``Content-Length`` header set.